### PR TITLE
Fix typo in README.md

### DIFF
--- a/packages/react-app-locale-utils/README.md
+++ b/packages/react-app-locale-utils/README.md
@@ -12,7 +12,7 @@ REACT_APP_LOCALES=["da-DK","en-US","es-ES","fi-FI","lt-LT","lv-LV","nb-NO","nl-N
 ### `useLocale`
 
 ```js
-import useDateFnsLocale from '@visma/react-app-locale-utils/lib/useLocale';
+import useLocale from '@visma/react-app-locale-utils/lib/useLocale';
 
 const [locale, setLocale] = useLocale();
 const [lang] = locale.split('-');


### PR DESCRIPTION
Change "useLocale" -examples import statement from useDateFnsLocale to useLocale